### PR TITLE
Fix broken legacy for laravel 4 (& 5.0)

### DIFF
--- a/src/SearchableTrait.php
+++ b/src/SearchableTrait.php
@@ -117,7 +117,7 @@ trait SearchableTrait
     {
         if (array_key_exists('columns', $this->searchable)) {
             $driver = $this->getDatabaseDriver();
-            $prefix = config("database.connections.$driver.prefix");
+            $prefix = Config::get("database.connections.$driver.prefix");
             $columns = [];
             foreach($this->searchable['columns'] as $column => $priority){
                 $columns[$prefix . $column] = $priority;


### PR DESCRIPTION
In this latest merge, you broke functionality on Laravel 4 (and 5.0) with the use of the helper function config() which was added in 5.1. 

Just simply changed it to Config::get() as the rest of the package uses.
